### PR TITLE
.gitignore: add 1password-credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dev/run_db.sh
 root.crt
 db/*.crt
 *config.json
+1password-credentials.json
+


### PR DESCRIPTION
The branch to add 1password credentials is still a work in progress, and to help keep other we just want to update .gitignore.